### PR TITLE
Stabilize random color generation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -62,5 +62,10 @@ def show_country_palo(df_country,name_df,random_colors):
     return fig
     
 def random_color():
-    
+
     return f'rgb({random.randint(0, 255)}, {random.randint(0, 255)}, {random.randint(0, 255)})'
+
+def get_random_colors(length, seed=None):
+    if seed:
+        random.seed(seed)
+    return [random_color() for _ in range(length)]

--- a/tradle_plus.py
+++ b/tradle_plus.py
@@ -5,7 +5,7 @@ import streamlit as st
 
 from datetime import datetime
 
-from src.utils import show_country, show_country_palo, random_color
+from src.utils import show_country, show_country_palo, get_random_colors
 #################################################
 # Wallpaper
 #################################################
@@ -124,7 +124,7 @@ for i in range(min(st.session_state.graficos+1,6)):
     if len (df_Country)==0:
         st.write(f'No valid graphs of {selected_graph_type} found for this country, la vida es dura.')
     else:
-        random_colors = [random_color() for _ in range(len(df_Country))]
+        random_colors = get_random_colors(length=len(df_Country), seed=current_date)
 
         fig = graph_function(df_Country) if selected_graph_type =='Tradle' else graph_function(df_Country,selected_graph_type, random_colors) 
 


### PR DESCRIPTION
Ahora mismo se observa un cambio de colores del primer gráfico al seleccionar un país. Esto se debe a que Streamlit siempre corre todo el código de nuevo cuando hay cambios así que, al seleccionar, se vuelven a elegir colores aleatorios.

Este PR simplemente da la opción de fijar un seed para esa selección. Al pasar el nombre del dataframe seleccionado nos aseguramos de que los colores para cada gráfico sigan siendo distintos pero también estables en el tiempo.